### PR TITLE
test pyproject.toml integration via doc: cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,14 +10,11 @@
  Invenio-Sitemap
 =====================
 
+.. image:: https://img.shields.io/pypi/v/invenio-sitemap.svg
+        :target: https://pypi.org/project/invenio-sitemap
+
 .. image:: https://github.com/inveniosoftware/invenio-sitemap/workflows/CI/badge.svg
         :target: https://github.com/inveniosoftware/invenio-sitemap/actions?query=workflow%3ACI
-
-.. image:: https://img.shields.io/github/tag/inveniosoftware/invenio-sitemap.svg
-        :target: https://github.com/inveniosoftware/invenio-sitemap/releases
-
-.. image:: https://img.shields.io/pypi/dm/invenio-sitemap.svg
-        :target: https://pypi.python.org/pypi/invenio-sitemap
 
 .. image:: https://img.shields.io/github/license/inveniosoftware/invenio-sitemap.svg
         :target: https://github.com/inveniosoftware/invenio-sitemap/blob/master/LICENSE
@@ -26,23 +23,23 @@
 *Sitemap indices and Sitemaps for InvenioRDM*
 
 Install
-===
+=======
 
-```bash
-uv pip install invenio-sitemap
-```
+.. code-block:: console
+
+    uv pip install invenio-sitemap
 
 Development and Testing
-===
+=======================
 
 Install for development and testing:
 
-```bash
-uv pip install -e .[tests]
-```
+.. code-block:: console
+
+    uv pip install -e .[tests]
 
 Run tests:
 
-```bash
-uv run --no-project ./run-tests.sh
-```
+.. code-block:: console
+
+    uv run ./run-tests.sh


### PR DESCRIPTION
This is just to test that our GH Actions to test works ok with a package using `pyproject.toml`. It fixes the README too.