### PR TITLE
fix contenttype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 0.1.2 (2025-06-13)
+
+- content-type: set to application/xml
+
 Version 0.1.1 (2025-05-15)
 
 - entrypoint: fix path to InvenioSitemap in pyproject.toml

--- a/invenio_sitemap/__init__.py
+++ b/invenio_sitemap/__init__.py
@@ -13,7 +13,7 @@ from .ext import InvenioSitemap
 from .sitemap import SitemapSection
 from .utils import format_to_w3c, iterate_urls_of_sitemap_indices
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = (
     "__version__",

--- a/invenio_sitemap/views.py
+++ b/invenio_sitemap/views.py
@@ -9,7 +9,7 @@
 """Views."""
 
 
-from flask import Blueprint, abort, render_template
+from flask import Blueprint, abort, make_response, render_template
 from invenio_cache import current_cache
 
 from .cache import SitemapCache, SitemapIndexCache
@@ -32,23 +32,30 @@ def _get_cached_or_404(cache_cls, page):
         abort(404)
 
 
+def xml_response(body):
+    """Wrap the body in an XML response."""
+    response = make_response(body)
+    response.headers["Content-Type"] = "application/xml"
+    return response
+
+
 @blueprint.route("/sitemap_index_<int:page>.xml", methods=["GET"])
 def sitemap_index(page):
     """Get the sitemap index."""
     entries = _get_cached_or_404(SitemapIndexCache, page)
-    return render_template(
+    sitemap_index = render_template(
         "invenio_sitemap/sitemap_index.xml",
-        mimetype="text/xml",
         entries=entries,
     )
+    return xml_response(sitemap_index)
 
 
 @blueprint.route("/sitemap_<int:page>.xml", methods=["GET"])
 def sitemap(page):
     """Get the sitemap page."""
     entries = _get_cached_or_404(SitemapCache, page)
-    return render_template(
+    sitemap = render_template(
         "invenio_sitemap/sitemap.xml",
-        mimetype="text/xml",
         entries=entries,
     )
+    return xml_response(sitemap)

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -82,6 +82,7 @@ def test_sitemap_has_valid_structure(client, primed_cache):
     resp = client.get("/sitemap_0.xml")
 
     assert 200 == resp.status_code
+    assert "application/xml" == resp.content_type
     schema.validate(resp.data)
 
 


### PR DESCRIPTION
This fixes the issue whereby the returned xml was served as html instead. (I must have originally stopped midway through implementation and when I picked the code backup I didn't think about it).

- **content-type: set to application/xml**
- **:package: release: v0.1.2**
