### PR TITLE
views: add configurable global `/sitemap.xml` view

### DIFF
--- a/invenio_sitemap/config.py
+++ b/invenio_sitemap/config.py
@@ -8,7 +8,6 @@
 
 """Configuration."""
 
-
 SITEMAP_MAX_ENTRY_COUNT = 10000
 """Maximum number of entries (<url> or <sitemap>) per file.
 
@@ -22,3 +21,6 @@ number of entries in the Sitemap Index and Sitemap files.
 
 SITEMAP_SECTIONS = []
 """Instances of `sitemap.SitemapSection` that will populate the Sitemap files."""
+
+SITEMAP_ROOT_VIEW_ENABLED = False
+"""Enable the `/sitemap.xml` endpoint serving the first sitemap index."""

--- a/invenio_sitemap/views.py
+++ b/invenio_sitemap/views.py
@@ -8,8 +8,7 @@
 
 """Views."""
 
-
-from flask import Blueprint, abort, make_response, render_template
+from flask import Blueprint, abort, current_app, make_response, render_template
 from invenio_cache import current_cache
 
 from .cache import SitemapCache, SitemapIndexCache
@@ -37,6 +36,19 @@ def xml_response(body):
     response = make_response(body)
     response.headers["Content-Type"] = "application/xml"
     return response
+
+
+@blueprint.route("/sitemap.xml", methods=["GET"])
+def sitemap_root():
+    """Get all sitemap root."""
+    if not current_app.config["SITEMAP_ROOT_VIEW_ENABLED"]:
+        abort(404)
+    entries = _get_cached_or_404(SitemapIndexCache, 0)
+    sitemap_index = render_template(
+        "invenio_sitemap/sitemap_index.xml",
+        entries=entries,
+    )
+    return xml_response(sitemap_index)
 
 
 @blueprint.route("/sitemap_index_<int:page>.xml", methods=["GET"])

--- a/tests/test_invenio_sitemap.py
+++ b/tests/test_invenio_sitemap.py
@@ -31,3 +31,25 @@ def test_init():
     assert "invenio-sitemap" not in app.extensions
     ext.init_app(app)
     assert "invenio-sitemap" in app.extensions
+
+
+def test_config_defaults():
+    """Test that default configuration values are set correctly."""
+    app = Flask("testapp")
+    ext = InvenioSitemap(app)
+
+    assert app.config.get("SITEMAP_ROOT_VIEW_ENABLED") is False
+    assert app.config.get("SITEMAP_MAX_ENTRY_COUNT") == 10000
+    assert app.config.get("SITEMAP_SECTIONS") == []
+
+
+def test_config_override():
+    """Test that configuration can be overridden."""
+    app = Flask("testapp")
+    app.config["SITEMAP_ROOT_VIEW_ENABLED"] = True
+    app.config["SITEMAP_MAX_ENTRY_COUNT"] = 5000
+
+    ext = InvenioSitemap(app)
+
+    assert app.config["SITEMAP_ROOT_VIEW_ENABLED"] is True
+    assert app.config["SITEMAP_MAX_ENTRY_COUNT"] == 5000

--- a/tests/test_sitemap_root.py
+++ b/tests/test_sitemap_root.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 Northwestern University.
+#
+# invenio-sitemap is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for the /sitemap.xml endpoint."""
+
+import xmlschema
+
+from invenio_sitemap.cache import SitemapIndexCache
+
+
+def test_sitemap_root_disabled_by_default(client, primed_cache):
+    """Test that /sitemap.xml returns 404 when disabled."""
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 404
+
+
+def test_sitemap_root_enabled_with_content(
+    client, primed_cache, set_app_config_fn_scoped
+):
+    """Test that /sitemap.xml works when enabled and returns first index page."""
+    set_app_config_fn_scoped({"SITEMAP_ROOT_VIEW_ENABLED": True})
+
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 200
+    assert resp.content_type == "application/xml"
+
+    # Verify it contains both sitemap index entries
+    assert b"<loc>https://127.0.0.1:5000/sitemap_0.xml</loc>" in resp.data
+    assert b"<loc>https://127.0.0.1:5000/sitemap_1.xml</loc>" in resp.data
+
+    # Verify lastmod dates are included
+    assert b"<lastmod>2025-02-02T06:00:00Z</lastmod>" in resp.data
+
+    # Validate against the sitemap index schema
+    schema = xmlschema.XMLSchema("tests/xsds/siteindex.xsd")
+    schema.validate(resp.data.decode("utf-8"))
+
+
+def test_sitemap_root_empty_cache(client, empty_cache, set_app_config_fn_scoped):
+    """Test that /sitemap.xml returns 404 when first index page is not cached."""
+    set_app_config_fn_scoped({"SITEMAP_ROOT_VIEW_ENABLED": True})
+
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 404
+
+
+def test_sitemap_root_only_first_page(client, empty_cache, set_app_config_fn_scoped):
+    """Test that /sitemap.xml only returns the first index page."""
+    set_app_config_fn_scoped({"SITEMAP_ROOT_VIEW_ENABLED": True})
+
+    # Manually populate cache with multiple index pages
+    sitemap_index_cache = SitemapIndexCache(empty_cache)
+
+    # Add first index page
+    sitemap_index_cache.set(
+        0,
+        [
+            {
+                "loc": "https://127.0.0.1:5000/sitemap_0.xml",
+                "lastmod": "2025-01-01T00:00:00Z",
+            },
+            {
+                "loc": "https://127.0.0.1:5000/sitemap_1.xml",
+                "lastmod": "2025-01-02T00:00:00Z",
+            },
+        ],
+    )
+
+    # Add second index page (should be ignored)
+    sitemap_index_cache.set(
+        1,
+        [
+            {
+                "loc": "https://127.0.0.1:5000/sitemap_2.xml",
+                "lastmod": "2025-01-03T00:00:00Z",
+            },
+            {
+                "loc": "https://127.0.0.1:5000/sitemap_3.xml",
+                "lastmod": "2025-01-04T00:00:00Z",
+            },
+        ],
+    )
+
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 200
+
+    # Verify only sitemaps from first index page are included
+    assert b"<loc>https://127.0.0.1:5000/sitemap_0.xml</loc>" in resp.data
+    assert b"<loc>https://127.0.0.1:5000/sitemap_1.xml</loc>" in resp.data
+    # These should NOT be included (from second index page)
+    assert b"<loc>https://127.0.0.1:5000/sitemap_2.xml</loc>" not in resp.data
+    assert b"<loc>https://127.0.0.1:5000/sitemap_3.xml</loc>" not in resp.data


### PR DESCRIPTION
The main reasoning for allowing for this endpoint is:

- Having an unpredictable number of sitemap indices makes it difficult to register them on the [Google developer console](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
- I have a feeling that most instances will not go over `10_000 sitemap indices * 10_000 entries = 100M entries` (unless of course they change `SITEMAP_MAX_ENTRY_COUNT`). For reference, Zenodo is almost at 6M entries after 10+ years of operation.
- It's sort of a "well-known" endpoint that crawlers look for. The ones who respect `robots.txt` will be fine, since in RDM the endpoint auto-populates them