### PR TITLE
WIP tasks: allow for custom sitemap index entry function

### DIFF
--- a/invenio_sitemap/config.py
+++ b/invenio_sitemap/config.py
@@ -8,7 +8,6 @@
 
 """Configuration."""
 
-
 SITEMAP_MAX_ENTRY_COUNT = 10000
 """Maximum number of entries (<url> or <sitemap>) per file.
 
@@ -22,3 +21,6 @@ number of entries in the Sitemap Index and Sitemap files.
 
 SITEMAP_SECTIONS = []
 """Instances of `sitemap.SitemapSection` that will populate the Sitemap files."""
+
+SITEMAP_INDEX_ENTRY_FUNC = None
+"""Function to generate the sitemap index entry."""

--- a/invenio_sitemap/tasks.py
+++ b/invenio_sitemap/tasks.py
@@ -101,6 +101,19 @@ def _get_latest_lastmod(entries):
     return result
 
 
+def _default_index_entry_func(page, lastmod):
+    """Default generator for sitemap index entries.
+
+    :param page: int. Index of the sitemap page.
+    :param lastmod: str. W3C datetime format.
+    :return: dict with 'loc' and 'lastmod' keys.
+    """
+    return {
+        "loc": invenio_url_for("invenio_sitemap.sitemap", page=page),
+        "lastmod": lastmod,
+    }
+
+
 def _iterate_sitemap_entries(lastmods):
     """Generate sitemap entries from lastmods.
 
@@ -108,7 +121,8 @@ def _iterate_sitemap_entries(lastmods):
     :yield: sitemap entry dict
     """
     for i, lastmod in enumerate(lastmods):
-        yield {
-            "loc": invenio_url_for("invenio_sitemap.sitemap", page=i),
-            "lastmod": lastmod,
-        }
+        index_entry_func = current_app.config.get(
+            "SITEMAP_INDEX_ENTRY_FUNC",
+            _default_index_entry_func,
+        )
+        yield index_entry_func(page=i, lastmod=lastmod)


### PR DESCRIPTION
- **WIP tasks: allow for custom sitemap index entry function**
  * Some Invenio instances do not have `invenio_url_for` configured. They
    should be able to swap this with their own function.
  